### PR TITLE
Update tangle_loss.py

### DIFF
--- a/core/loss/tangle_loss.py
+++ b/core/loss/tangle_loss.py
@@ -10,7 +10,7 @@ def apply_random_mask(patch_embeddings, percentage):
     mask_count = int(percentage * dim_size)
     mask = torch.cat([torch.zeros(mask_count), torch.ones(dim_size - mask_count)])
     mask = mask[torch.randperm(dim_size)].unsqueeze(0).unsqueeze(-1)
-    return patch_embeddings*mask_count
+    return patch_embeddings*mask
     
 
 def init_intra_wsi_loss_function(config):


### PR DESCRIPTION
The mask_count is an integer representing the number of elements to mask, but we need to multiply the patch_embeddings by the mask tensor to apply the mask correctly.